### PR TITLE
go/types: Unmarhal error is fixed

### DIFF
--- a/enrichment_impl.go
+++ b/enrichment_impl.go
@@ -30,8 +30,8 @@ func (e *enrichment) Combined(email string) (*CombinedResponse, error) {
 
 	c := &CombinedResponse{}
 	if err := json.Unmarshal(body, &c); err != nil {
-		e := err.(*json.UnmarshalTypeError)
-		fmt.Println(string(body[e.Offset-50 : e.Offset+50]))
+		e := err.(*json.UnmarshalFieldError)
+		fmt.Println(string(body[e.Field.Offset-50 : e.Field.Offset+50]))
 		return nil, err
 	}
 


### PR DESCRIPTION
Hi Prateek ,
There was an error about UnmarshalTypeError has no field Offset, so i've changed UnMarshalError struct.
